### PR TITLE
ES2015 and beyond

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -363,6 +363,26 @@ const foo = {
 foo[propertyName];
 ```
 
++ Use object destructuring when accessing multiple properties on an object.
+
+```javascript
+// BAD:
+function foo(person) {
+  const name = person.name;
+  const age = person.age;
+  const height = person.height;
+
+  return `${name} is ${age} years old and ${height} tall.`
+}
+
+// GOOD:
+function foo(person) {
+  const { name, age, height } = person;
+
+  return `${name} is ${age} years old and ${height} tall.`
+}
+```
+
 ## Functions
 
 + Use object method shorthand.

--- a/javascript.md
+++ b/javascript.md
@@ -542,6 +542,19 @@ const foo = {
 [1, 2, 3].map((x) => x * x);
 ```
 
++ If the function body fits on one line, feel free to omit the braces and use
+implicit return. Otherwise, add the braces and use a return statement.
+
+```javascript
+// GOOD:
+[1, 2, 3].map((x) => x * x);
+
+// GOOD:
+[1, 2, 3].map((x) => {
+  return { number: x };
+});
+```
+
 ## Function Arguments
 
 + Never use `arguments` – use rest instead.

--- a/javascript.md
+++ b/javascript.md
@@ -12,6 +12,10 @@
 * [Variables](#variables)
 * [Whitespace](#whitespace)
 
+### Constructors
+
+* [Constructors](#constructors)
+
 ### Objects
 
 * [Objects](#objects)
@@ -301,6 +305,46 @@ foo();
 ```
 
 + No trailing whitespace.
+
+## Constructors
+
++ Use `class` instead of manipulating `prototype`.
+
+```javascript
+// BAD:
+function Car(make = 'Tesla') {
+  this.make = make;
+  this.position = { x: 0, y: 0 };
+}
+
+Car.prototype.move = function(x = 0, y = 0) {
+  this.position = { x, y };
+  return this.position;
+}
+
+// GOOD:
+class Car {
+  constructor(make = 'Tesla') {
+    this.make = make;
+    this.position = { x: 0, y: 0 };
+  }
+
+  move(x = 0, y = 0) {
+    this.position = { x, y };
+    return this.position;
+  }
+}
+```
+
++ Use `extends` for inheritance.
+
+```javascript
+class HondaCivic extends Car {
+  constructor() {
+    super('Honda');
+  }
+}
+```
 
 ## Objects
 

--- a/javascript.md
+++ b/javascript.md
@@ -324,14 +324,14 @@ const foo = ['a', 'b', 'c'];
 + Use array destructuring.
 
 ```javascript
-const arr = [1, 2, 3, 4];
+let arr = [1, 2, 3, 4];
 
 // BAD:
 const head = arr.shift();
 const tail = arr;
 
 // GOOD:
-const [ head, ...tail ] = arr;
+const [head, ...tail] = arr;
 ```
 
 ## Properties

--- a/javascript.md
+++ b/javascript.md
@@ -365,21 +365,28 @@ foo[propertyName];
 
 ## Functions
 
-+ Make sure to name functions when you define them.
++ Use object method shorthand.
 
 ```javascript
-function fooBar() {
-}
+// BAD:
+const foo = {
+  value: 0,
 
-var foo = {
-  bar: function foo_bar() {
-    // code
+  bar: function bar(value) {
+    return foo.value + value;
   }
-};
+}
+```
 
-var foo = function foo() {
-  // code
-};
+```javascript
+// GOOD:
+const foo = {
+  value: 0,
+
+  bar(value) {
+    return foo.value + value;
+  }
+}
 ```
 
 + Use scope to lookup functions (not variables).

--- a/javascript.md
+++ b/javascript.md
@@ -17,6 +17,10 @@
 * [Objects](#objects)
 * [Properties](#properties)
 
+### Strings
+
+* [Strings](#strings)
+
 ### Arrays
 
 * [Arrays](#arrays)
@@ -283,6 +287,32 @@ const foo = {};
 
 ```javascript
 const bar = { color: 'orange' };
+```
+
+## Strings
+
++ Prefer single quotes, and use double quotes to avoid escaping.
+
+```javascript
+// BAD:
+const foo = "bar";
+
+// GOOD:
+const foo = 'bar';
+const baz = "What's this?;
+```
+
++ When constructing strings with dynamic values, prefer template strings.
+
+```javascript
+const prefix = 'Hello';
+const suffix = 'and have a good day.';
+
+// BAD:
+return prefix + ' world, ' + suffix;
+
+// GOOD:
+return `${prefix} world, ${suffix}`
 ```
 
 ## Arrays

--- a/javascript.md
+++ b/javascript.md
@@ -206,7 +206,19 @@ function foo() {
 requiring mutability.
 
 ```javascript
+// BAD:
+var a = [1, 2, 3];
+let b = [1, 2, 3];
+
+// GOOD:
 const a = [1, 2, 3];
+let b = [4, 5, 6];
+
+function doStuff() {
+  b = [1, 2, 3];
+
+  return b;
+}
 ```
 
 + Note that both `let` and `const` are block scoped.

--- a/javascript.md
+++ b/javascript.md
@@ -299,7 +299,7 @@ const foo = "bar";
 
 // GOOD:
 const foo = 'bar';
-const baz = "What's this?;
+const baz = "What's this?";
 ```
 
 + When constructing strings with dynamic values, prefer template strings.

--- a/javascript.md
+++ b/javascript.md
@@ -494,14 +494,26 @@ let foo = [];
 foo.push('bar');
 ```
 
-+ Use spread to join 2 arrays.
++ Use spread.
 
 ```javascript
+// join 2 arrays
 let foo = [0, 1, 2];
 let bar = [3, 4, 5];
 
 foo.push(...bar);
+
+// avoid using `Function.prototype.apply`
+const values = [25, 50, 75, 100];
+
+// good
+const max = Math.max.apply(Math, values);
+
+// better
+const max = Math.max(...values);
 ```
+
++ Use spre
 
 + Join single line array items with a space.
 

--- a/javascript.md
+++ b/javascript.md
@@ -189,7 +189,7 @@ const bar = {
 
 ```javascript
 function foo() {
-  let bar = 5;
+  const bar = 5;
 
   // multiplies `bar` by 2.
   fooBar(bar);
@@ -490,7 +490,7 @@ const foo = new Array(16);
 + Use `push` to add an item to an array.
 
 ```javascript
-let foo = [];
+const foo = [];
 foo.push('bar');
 ```
 
@@ -498,8 +498,8 @@ foo.push('bar');
 
 ```javascript
 // join 2 arrays
-let foo = [0, 1, 2];
-let bar = [3, 4, 5];
+const foo = [0, 1, 2];
+const bar = [3, 4, 5];
 
 foo.push(...bar);
 
@@ -513,8 +513,6 @@ const max = Math.max.apply(Math, values);
 const max = Math.max(...values);
 ```
 
-+ Use spre
-
 + Join single line array items with a space.
 
 ```javascript
@@ -524,7 +522,7 @@ const foo = ['a', 'b', 'c'];
 + Use array destructuring.
 
 ```javascript
-let arr = [1, 2, 3, 4];
+const arr = [1, 2, 3, 4];
 
 // BAD:
 const head = arr.shift();

--- a/javascript.md
+++ b/javascript.md
@@ -323,6 +323,25 @@ var foo = ['a', 'b', 'c'];
 
 ## Properties
 
++ Use property value shorthand.
+
+```javascript
+const name = 'Derek Zoolander';
+const age = 25;
+
+// BAD:
+const foo = {
+  name: name,
+  age: age
+}
+
+// GOOD:
+const foo = {
+  name,
+  age
+}
+```
+
 + Use dot-notation when accessing properties.
 
 ```javascript

--- a/javascript.md
+++ b/javascript.md
@@ -77,7 +77,8 @@ try {
 }
 ```
 
-+ Opening curly brace (`{`) should be on the same line as the beginning of a statement or declaration.
++ Opening curly brace (`{`) should be on the same line as the beginning of a
+statement or declaration.
 
 ```javascript
 function foo() {
@@ -132,7 +133,8 @@ if (notFound) {
 }
 ```
 
-+ Use explicit conditions when checking for non `null`, `undefined`, `true`, `false` values.
++ Use explicit conditions when checking for non `null`, `undefined`, `true`,
+`false` values.
 
 ```javascript
 if (arr.length > 0) {
@@ -347,7 +349,7 @@ class Validator {
 
 const presenceValidator = new Validator({
   rules: {}
-})
+});
 ```
 
 + Prefix with an underscore `_` when naming private properties or methods.
@@ -360,7 +362,7 @@ const foo = {
   somePrivateMethod_() {
     console.log(this.__firstName__);
   }
-}
+};
 
 // GOOD:
 const foo = {
@@ -369,7 +371,7 @@ const foo = {
   _somePrivateMethod() {
     console.log(this._firstName);
   }
-}
+};
 ```
 
 ## Constructors
@@ -460,7 +462,8 @@ return `${prefix} world, ${suffix}`;
 const foo = [];
 ```
 
-+ Use new Array if you know the exact length of the array and know that its length will not change.
++ Use `new Array`` if you know the exact length of the array and know that its
+length will not change.
 
 ```javascript
 const foo = new Array(16);
@@ -654,6 +657,11 @@ const foo = {
     return items.map((item) => {
       return this.base + item.value;
     });
+  }
+
+  // GOOD:
+  bar(items) {
+    return items.map((item) => this.base + item.value);
   }
 };
 ```

--- a/javascript.md
+++ b/javascript.md
@@ -202,6 +202,17 @@ requiring mutability.
 const a = [1, 2, 3];
 ```
 
++ Note that both `let` and `const` are block scoped.
+
+```javascript
+{
+  let a = 1;
+  const b = 2;
+}
+console.log(a); // ReferenceError
+console.log(b); // ReferenceError
+```
+
 + Put all non-assigning declarations on one line.
 
 ```javascript

--- a/javascript.md
+++ b/javascript.md
@@ -35,10 +35,6 @@
 * [Functions](#functions)
 * [Function Arguments](#function-arguments)
 
-### Modules
-
-* [Modules](#modules)
-
 ## Block Statements
 
 + Use spaces before leading brace.
@@ -749,28 +745,4 @@ function fooBar(obj = {}, key = 'id', value = 0) {
     return obj[key];
   }
 }
-```
-
-## Modules
-
-+ Do not use wildcard imports.
-
-```javascript
-// BAD:
-import * as Ember from 'ember';
-
-// GOOD:
-import Ember from 'ember';
-```
-
-+ Do not `export` directly from an `import`.
-
-```javascript
-// BAD:
-export { Mixin as default } from 'my-mixin';
-
-// GOOD:
-import { Mixin } from 'my-mixin';
-
-export default Mixin;
 ```

--- a/javascript.md
+++ b/javascript.md
@@ -11,6 +11,7 @@
 * [Comments](#comments)
 * [Variables](#variables)
 * [Whitespace](#whitespace)
+* [Naming conventions](#naming-conventions)
 
 ### Constructors
 
@@ -309,6 +310,67 @@ foo();
 ```
 
 + No trailing whitespace.
+
+## Naming Conventions
+
++ Be descriptive with naming.
+
+```javascript
+// BAD:
+function check(k, v = 0) {
+  // ...
+}
+
+// GOOD:
+function checkValidKey(key, value = 0) {
+  // ...
+}
+```
+
++ Use PascalCase only for constructors or classes.
+
+```javascript
+// BAD:
+
+function Validate(options) {
+  // ...
+}
+
+const validatedItem = Validate(item);
+
+// GOOD:
+class Validator {
+  constructor(options) {
+    this.rules = options.rules;
+  }
+}
+
+const presenceValidator = new Validator({
+  rules: {}
+})
+```
+
++ Prefix with an underscore `_` when naming private properties or methods.
+
+```javascript
+// BAD:
+const foo = {
+  __firstName__: 'Yehuda',
+
+  somePrivateMethod_() {
+    console.log(this.__firstName__);
+  }
+}
+
+// GOOD:
+const foo = {
+  _firstName: 'Yehuda',
+
+  _somePrivateMethod() {
+    console.log(this._firstName);
+  }
+}
+```
 
 ## Constructors
 

--- a/javascript.md
+++ b/javascript.md
@@ -532,6 +532,16 @@ const foo = {
 };
 ```
 
++ Always use parentheses around arguments.
+
+```javascript
+// BAD:
+[1, 2, 3].map(x => x * x);
+
+// GOOD:
+[1, 2, 3].map((x) => x * x);
+```
+
 ## Function Arguments
 
 + Never use `arguments` – use rest instead.

--- a/javascript.md
+++ b/javascript.md
@@ -213,6 +213,22 @@ console.log(a); // ReferenceError
 console.log(b); // ReferenceError
 ```
 
++ Group your `const`s and then group your `let`s.
+
+```javascript
+// BAD:
+let foo;
+const bar = 123;
+let arr = [1, 2, 3];
+const isTrue = true;
+
+// GOOD:
+const isTrue = true;
+const bar = 123;
+let foo;
+let arr = [1, 2, 3];
+```
+
 + Put all non-assigning declarations on one line.
 
 ```javascript

--- a/javascript.md
+++ b/javascript.md
@@ -306,6 +306,15 @@ var foo = [];
 foo.push('bar');
 ```
 
++ Use spread to join 2 arrays.
+
+```javascript
+let foo = [0, 1, 2];
+let bar = [3, 4, 5];
+
+foo.push(...bar);
+```
+
 + Join single line array items with a space.
 
 ```javascript

--- a/javascript.md
+++ b/javascript.md
@@ -312,7 +312,7 @@ const suffix = 'and have a good day.';
 return prefix + ' world, ' + suffix;
 
 // GOOD:
-return `${prefix} world, ${suffix}`
+return `${prefix} world, ${suffix}`;
 ```
 
 ## Arrays

--- a/javascript.md
+++ b/javascript.md
@@ -5,7 +5,7 @@
 ### Grammar
 
 * [Block Statements](#block-statements)
-* [Conditional Statements] (#conditional-statements)
+* [Conditional Statements](#conditional-statements)
 * [Commas](#commas)
 * [Semicolons](#semicolons)
 * [Comments](#comments)
@@ -410,6 +410,29 @@ function foo() {
   bar();
 }
 ```
+
++ Use fat arrows to preserve `this` when using function expressions or
+anonymous functions.
+
+```javascript
+const foo = {
+  base: 0,
+
+  // BAD:
+  bar(items) {
+    const _this = this;
+    return items.map(function(item) {
+      return _this.base + item.value;
+    });
+  }
+
+  // GOOD:
+  bar(items) {
+    return items.map((item) => {
+      return this.base + item.value;
+    });
+  }
+}
 
 ## Function Arguments
 

--- a/javascript.md
+++ b/javascript.md
@@ -321,6 +321,19 @@ foo.push(...bar);
 const foo = ['a', 'b', 'c'];
 ```
 
++ Use array destructuring.
+
+```javascript
+const arr = [1, 2, 3, 4];
+
+// BAD:
+const head = arr.shift();
+const tail = arr;
+
+// GOOD:
+const [ head, ...tail ] = arr;
+```
+
 ## Properties
 
 + Use property value shorthand.

--- a/javascript.md
+++ b/javascript.md
@@ -452,12 +452,23 @@ function fooBar(_opt) {
 }
 ```
 
-+ Use a new variable if you need to re-assign an argument.
++ Use default params instead of mutating them.
 
 ```javascript
-function fooBar(opt) {
-  var options = opt;
+// BAD:
+function fooBar(obj, key = 'id', value = 0) {
+  obj = obj || {};
+  key = key || 'id';
+  // ...
+}
 
-  options = 3;
+// GOOD:
+function fooBar(obj = {}, key = 'id', value = 0) {
+  if (key) {
+    return obj[key];
+  } else {
+    obj[key] = value;
+    return obj[key];
+  }
 }
 ```

--- a/javascript.md
+++ b/javascript.md
@@ -202,8 +202,8 @@ function foo() {
 
 ## Variables
 
-+ Never use `var`. Prefer `const` to declare variables, unless explicitly
-requiring mutability.
++ Never use `var`. Prefer `const` to declare variables with a constant reference
+(not value), and `let` to declare variables with a variable reference.
 
 ```javascript
 // BAD:
@@ -219,6 +219,16 @@ function doStuff() {
 
   return b;
 }
+```
+
++ Note that `const` refers to a **constant reference**, not a constant value.
+
+```javascript
+const coolKids = ['Estelle', 'Lauren', 'Romina'];
+coolKids.push('Marin');
+console.log(coolKids); // ['Estelle', 'Lauren', 'Romina', 'Marin']
+
+coolKids = ['Doug', 'Lin', 'Dan']; // SyntaxError: "coolKids" is read-only
 ```
 
 + Note that both `let` and `const` are block scoped.

--- a/javascript.md
+++ b/javascript.md
@@ -413,22 +413,23 @@ function foo() {
 
 ## Function Arguments
 
-`arguments` object must not be passed or leaked anywhere.
-See the [reference](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#3-managing-arguments).
-
-+ Use a `for` loop with `arguments` (instead of `slice`).
++ Never use `arguments` – use rest instead.
 
 ```javascript
-function fooBar() {
-  var args = new Array(arguments.length);
+// BAD:
+function foo() {
+  const args = Array.prototype.slice.call(arguments);
+  return args.join('');
+}
 
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
-  }
-
-  return args;
+// GOOD:
+function foo(...args) {
+  return args.join('');
 }
 ```
+
+`arguments` object must not be passed or leaked anywhere.
+See the [reference](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#3-managing-arguments).
 
 + Don't re-assign the arguments.
 

--- a/javascript.md
+++ b/javascript.md
@@ -396,6 +396,29 @@ const foo = {
 };
 ```
 
++ Group shorthand properties at the beginning.
+
+```javascript
+const name = 'Derek Zoolander';
+const age = 25;
+
+// BAD:
+const foo = {
+  currentShow: 'Derelicte',
+  name,
+  enemy: 'Hansel',
+  age
+};
+
+// GOOD:
+const foo = {
+  name,
+  age,
+  currentShow: 'Derelicte',
+  enemy: 'Hansel'
+};
+```
+
 + Use dot-notation when accessing properties.
 
 ```javascript
@@ -507,6 +530,7 @@ const foo = {
     });
   }
 };
+```
 
 ## Function Arguments
 

--- a/javascript.md
+++ b/javascript.md
@@ -45,11 +45,11 @@ switch (condition) {
 }
 
 // loops
-for (var key in keys) {
+for (const key in keys) {
   // code
 }
 
-for (var i = 0, l = keys.length; i < l; i++) {
+for (let i = 0, l = keys.length; i < l; i++) {
   // code
 }
 
@@ -68,7 +68,7 @@ try {
 
 ```javascript
 function foo() {
-  var obj = {
+  const obj = {
     val: 'test'
   };
 
@@ -81,7 +81,7 @@ if (foo === 1) {
   foo();
 }
 
-for (var key in keys) {
+for (let key in keys) {
   bar(e);
 }
 
@@ -144,15 +144,15 @@ if (foo === 'bar') {
 + Skip trailing commas.
 
 ```javascript
-var foo = [1, 2, 3];
-var bar = { a: 'a' };
+const foo = [1, 2, 3];
+const bar = { a: 'a' };
 ```
 
 + Skip trailing and leading commas.
 
 ```javascript
-var foo = [1, 2, 3];
-var bar = {
+const foo = [1, 2, 3];
+const bar = {
   a: 'a',
   b: 'b'
 };
@@ -178,7 +178,7 @@ var bar = {
 
 ```javascript
 function foo() {
-  var bar = 5;
+  let bar = 5;
 
   // multiplies `bar` by 2.
   fooBar(bar);
@@ -201,21 +201,21 @@ const a = [1, 2, 3];
 + Put all non-assigning declarations on one line.
 
 ```javascript
-var a, b;
+let a, b;
 ```
 
-+ Use a single `var` declaration for each assignment.
++ Use a single `const` declaration for each assignment.
 
 ```javascript
-var a = 1;
-var b = 2;
+const a = 1;
+const b = 2;
 ```
 
 + Declare variables at the top of their block scope.
 
 ```javascript
 function foo() {
-  var bar;
+  let bar;
 
   console.log('foo bar!');
 
@@ -223,11 +223,11 @@ function foo() {
 }
 
 function bar() {
-  var coolList;
+  let coolList;
 
   // code
 
-  for (var index = 0, length = coolThing.length; index < length; index++) {
+  for (let index = 0, length = coolThing.length; index < length; index++) {
     // code
   }
 }
@@ -239,7 +239,7 @@ function bar() {
 
 ```javascript
 function() {
-∙∙var name;
+∙∙const name;
 }
 ```
 
@@ -257,7 +257,7 @@ test('foo-bar', function() {
 + No spaces before semicolons.
 
 ```javascript
-var foo = {};
+const foo = {};
 ```
 
 + Keep parenthesis adjacent to the function name when declared or called.
@@ -276,13 +276,13 @@ foo();
 + Use literal form for object creation.
 
 ```javascript
-var foo = {};
+const foo = {};
 ```
 
 + Pad single-line objects with white-space.
 
 ```javascript
-var bar = { color: 'orange' };
+const bar = { color: 'orange' };
 ```
 
 ## Arrays
@@ -290,19 +290,19 @@ var bar = { color: 'orange' };
 + Use literal form for array creation (unless you know the exact length).
 
 ```javascript
-var foo = [];
+const foo = [];
 ```
 
 + Use new Array if you know the exact length of the array and know that its length will not change.
 
 ```javascript
-var foo = new Array(16);
+const foo = new Array(16);
 ```
 
 + Use `push` to add an item to an array.
 
 ```javascript
-var foo = [];
+let foo = [];
 foo.push('bar');
 ```
 
@@ -318,7 +318,7 @@ foo.push(...bar);
 + Join single line array items with a space.
 
 ```javascript
-var foo = ['a', 'b', 'c'];
+const foo = ['a', 'b', 'c'];
 ```
 
 ## Properties
@@ -345,7 +345,7 @@ const foo = {
 + Use dot-notation when accessing properties.
 
 ```javascript
-var foo = {
+const foo = {
   bar: 'bar'
 };
 
@@ -355,8 +355,8 @@ foo.bar;
 + Use `[]` when accessing properties via a variable.
 
 ```javascript
-var propertyName = 'bar';
-var foo = {
+const propertyName = 'bar';
+const foo = {
   bar: 'bar'
 };
 
@@ -403,7 +403,7 @@ function foo() {
 
 // BAD:
 function foo() {
-  var bar = function bar() {
+  const bar = function bar() {
     // code
   }
 
@@ -446,7 +446,7 @@ function fooBar(opt) {
 
 // Use a new variable if you need to assign the value of an argument
 function fooBar(_opt) {
-  var opt = _opt;
+  const opt = _opt;
 
   opt = 3;
 }

--- a/javascript.md
+++ b/javascript.md
@@ -191,6 +191,13 @@ function foo() {
 
 ## Variables
 
++ Never use `var`. Prefer `const` to declare variables, unless explicitly
+requiring mutability.
+
+```javascript
+const a = [1, 2, 3];
+```
+
 + Put all non-assigning declarations on one line.
 
 ```javascript

--- a/javascript.md
+++ b/javascript.md
@@ -376,13 +376,13 @@ const age = 25;
 const foo = {
   name: name,
   age: age
-}
+};
 
 // GOOD:
 const foo = {
   name,
   age
-}
+};
 ```
 
 + Use dot-notation when accessing properties.
@@ -438,7 +438,7 @@ const foo = {
   bar: function bar(value) {
     return foo.value + value;
   }
-}
+};
 ```
 
 ```javascript
@@ -449,7 +449,7 @@ const foo = {
   bar(value) {
     return foo.value + value;
   }
-}
+};
 ```
 
 + Use scope to lookup functions (not variables).
@@ -487,7 +487,7 @@ const foo = {
     return items.map(function(item) {
       return _this.base + item.value;
     });
-  }
+  },
 
   // GOOD:
   bar(items) {
@@ -495,7 +495,7 @@ const foo = {
       return this.base + item.value;
     });
   }
-}
+};
 
 ## Function Arguments
 
@@ -520,12 +520,12 @@ See the [reference](https://github.com/petkaantonov/bluebird/wiki/Optimization-k
 + Don't re-assign the arguments.
 
 ```javascript
-// Don't re-assigning the arguments
+// Don't re-assign the arguments
 function fooBar() {
   arguments = 3;
 }
 
-// Don't re-assigning the arguments
+// Don't re-assign the arguments
 function fooBar(opt) {
   opt = 3;
 }
@@ -542,7 +542,7 @@ function fooBar(_opt) {
 
 ```javascript
 // BAD:
-function fooBar(obj, key = 'id', value = 0) {
+function fooBar(obj, key, value) {
   obj = obj || {};
   key = key || 'id';
   // ...

--- a/javascript.md
+++ b/javascript.md
@@ -29,10 +29,14 @@
 
 * [Arrays](#arrays)
 
-## Functions
+### Functions
 
 * [Functions](#functions)
 * [Function Arguments](#function-arguments)
+
+### Modules
+
+* [Modules](#modules)
 
 ## Block Statements
 
@@ -675,4 +679,28 @@ function fooBar(obj = {}, key = 'id', value = 0) {
     return obj[key];
   }
 }
+```
+
+## Modules
+
++ Do not use wildcard imports.
+
+```javascript
+// BAD:
+import * as Ember from 'ember';
+
+// GOOD:
+import Ember from 'ember';
+```
+
++ Do not `export` directly from an `import`.
+
+```javascript
+// BAD:
+export { Mixin as default } from 'my-mixin';
+
+// GOOD:
+import { Mixin } from 'my-mixin';
+
+export default Mixin;
 ```


### PR DESCRIPTION
Open for discussion and review.

**Making atomic commits for easier discussion.**

The purpose of this PR is to initiate discussion about best practices that we should adopt at DockYard regarding the use of ES2015 syntax. Since the introduction of `ember-cli-babel` into `ember-cli`, ES2015 (and beyond) syntax is proposed to be our default syntax of choice where available.

ES2015 specific:

- [x] Fat arrows
- [x] Classes
- [x] Destructuring
- [x] Template strings
- [x] Prefer `let` and `const` over `var`
  - [x] Mention block scope
- [x] Default, rest, spread
- [x] Property value shorthand
- [x] Object method shorthand 
- [x] Modules

Other:
- [x] Naming conventions

For another PR:
- Always show `good` and `bad` examples
- Include a "Why" section for each point