### PR TITLE
Fix: Javascript: Markdown broken links

### DIFF
--- a/engineering/javascript.md
+++ b/engineering/javascript.md
@@ -15,24 +15,24 @@
 
 ### Constructors
 
-* [Constructors](#constructors)
+* [Constructors](#constructors-1)
 
 ### Objects
 
-* [Objects](#objects)
+* [Objects](#objects-1)
 * [Properties](#properties)
 
 ### Strings
 
-* [Strings](#strings)
+* [Strings](#strings-1)
 
 ### Arrays
 
-* [Arrays](#arrays)
+* [Arrays](#arrays-1)
 
 ### Functions
 
-* [Functions](#functions)
+* [Functions](#functions-1)
 * [Function Arguments](#function-arguments)
 
 ## Block Statements


### PR DESCRIPTION
# Fix broken links

Some links are broken because header's ids are not unique so what Github does to ensure uniqueness is adding a consecutive number at the end of the indentifier. 

Ex: `#objects, #objects-1, ...`
