### PR TITLE
Fix: Javascript: Markdown broken links

### DIFF
--- a/engineering/javascript.md
+++ b/engineering/javascript.md
@@ -2,38 +2,27 @@
 
 ## Table Of Contents
 
-### Grammar
-
-* [Block Statements](#block-statements)
-* [Conditional Statements](#conditional-statements)
-* [Commas](#commas)
-* [Semicolons](#semicolons)
-* [Comments](#comments)
-* [Assignment](#assignment)
-* [Whitespace](#whitespace)
-* [Naming conventions](#naming-conventions)
-
-### Constructors
-
-* [Constructors](#constructors)
-
-### Objects
-
-* [Objects](#objects)
-* [Properties](#properties)
-
-### Strings
-
-* [Strings](#strings)
-
-### Arrays
-
-* [Arrays](#arrays)
-
-### Functions
-
-* [Functions](#functions)
-* [Function Arguments](#function-arguments)
+* **Grammar**
+  * [Block Statements](#block-statements)
+  * [Conditional Statements](#conditional-statements)
+  * [Commas](#commas)
+  * [Semicolons](#semicolons)
+  * [Comments](#comments)
+  * [Assignment](#assignment)
+  * [Whitespace](#whitespace)
+  * [Naming conventions](#naming-conventions)
+* **Constructors**
+  * [Constructors](#constructors)
+* **Objects**
+  * [Objects](#objects)
+  * [Properties](#properties)
+* **Strings**
+  * [Strings](#strings)
+* **Arrays**
+  * [Arrays](#arrays)
+* **Functions**
+  * [Functions](#functions)
+  * [Function Arguments](#function-arguments)
 
 ## Block Statements
 


### PR DESCRIPTION
# Fix broken links

Some links are broken because header's ids are not unique so what Github does to ensure uniqueness is adding a consecutive number at the end of the identifier. 

Applied updated requested in PR #119 