### PR TITLE
Adjust the example YUIDoc format

### DIFF
--- a/engineering/javascript.md
+++ b/engineering/javascript.md
@@ -238,8 +238,8 @@ const potato = [
 ```javascript
 // good
 /**
-  This is documentation for something just below.
-*/
+ * This is documentation for something just below.
+ */
 function isItLunchTimeYet(time) {
   if (time) {
     return 'Yes.';


### PR DESCRIPTION
The style guide included a link to the [YUIDoc Syntax Reference](http://yui.github.io/yuidoc/syntax/index.html) but the asterisks and spacing in our style guide were slightly different than the one at the link.

If we want to follow the exact format, then we should make this change; otherwise we can close the PR without merging.